### PR TITLE
Switches from crypto to hash.js for bundle size

### DIFF
--- a/lib/RdfIsomorphic.ts
+++ b/lib/RdfIsomorphic.ts
@@ -1,4 +1,4 @@
-import {createHash} from "crypto";
+import {sha1} from "hash.js";
 import * as RDF from "rdf-js";
 import {quadToStringQuad, stringQuadToQuad, termToString} from "rdf-string";
 import {everyTerms, getBlankNodes, getTerms, someTerms, uniqTerms, getTermsNested} from "rdf-terms";
@@ -317,7 +317,7 @@ export function hashTerm<Q extends RDF.BaseQuad = RDF.Quad>(term: RDF.Term, quad
  * @return {string} A hash string.
  */
 export function sha1hex(data: string | Buffer | NodeJS.TypedArray | DataView): string {
-  return createHash('sha1').update(data).digest('hex');
+  return sha1().update(data).digest('hex');
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "version": "manual-git-changelog onversion"
   },
   "dependencies": {
+    "hash.js": "^1.1.7",
     "rdf-string": "^1.5.0",
     "rdf-terms": "^1.6.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1748,6 +1748,14 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
+hash.js@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.1"
+
 hosted-git-info@^2.1.4:
   version "2.8.5"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.5.tgz#759cfcf2c4d156ade59b0b2dfabddc42a6b9c70c"
@@ -2780,6 +2788,11 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+minimalistic-assert@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
 minimatch@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
Hi there!

While working on [quadstore](https://github.com/beautifulinteractions/node-quadstore) I noticed that the bundle size of  [quadstore-comunica](https://github.com/beautifulinteractions/node-quadstore-comunica) grows significantly when I add the [SPARQL parser actor](https://github.com/comunica/comunica/tree/master/packages/actor-sparql-parse-algebra). Such actor depends on [sparqlalgebrajs](https://github.com/joachimvh/SPARQLAlgebra.js), which in turn depends on `rdf-isomorphic.js` (this module) which in turn uses `crypto`, causing Webpack to pull in a lot of stuff that is not actually needed.

https://github.com/jacoscaz/rdf-isomorphic.js/blob/f10cf59d972a715000ac059e6e3fad65a009cdf3/lib/RdfIsomorphic.ts#L1

Following the lead set in https://github.com/comunica/comunica/commit/bc439e9e2e5a773f45964f567abbf863ef83e0cb , I've replaced the only usage of `crypto` with `hash.js`.